### PR TITLE
Added command npm init to the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ ready to be installed and compiled.
 
 Run the following command from within your sub-theme directory:
 
+    npm init
     npm run build
 
 ## Development documentation


### PR DESCRIPTION
Realised I needed an `npm init` when trying to start with civictheme for ARPANSA. 