### PR TITLE
Upgrade Logger to work with Drush 11.

### DIFF
--- a/civictheme.provision.inc
+++ b/civictheme.provision.inc
@@ -229,7 +229,7 @@ function civictheme_provision_cli() {
  */
 function civictheme_provision_cli_log($message) {
   if (class_exists('\Drush\Drush')) {
-    Drush::getContainer()->get('logger')->log(LogLevel::OK, strip_tags(html_entity_decode($message)));
+    Drush::getContainer()->get('logger')->notice(strip_tags(html_entity_decode($message)));
   }
   elseif (PHP_SAPI === 'cli') {
     print strip_tags(html_entity_decode($message)) . PHP_EOL;


### PR DESCRIPTION
Currently, when using Drush 11 the error is produced:
```Psr\Log\InvalidArgumentException]  
  The log level "ok" does not exist. 
```