### PR TITLE
Bust browser cache on colour cache invalidation.

### DIFF
--- a/src/CivicthemeColorManager.php
+++ b/src/CivicthemeColorManager.php
@@ -345,6 +345,9 @@ class CivicthemeColorManager implements ContainerInjectionInterface {
     $this->stylesheetGenerator->purge();
 
     $this->cacheTagsInvalidator->invalidateTags(['library_info']);
+    
+    // Force browser reload by changing the dummy query string.
+    _drupal_flush_css_js();
 
     return $this;
   }


### PR DESCRIPTION
## Problem
When re-generating colour CSS file it still utilises the old dummy query string. This causes browsers to serve cached version of the asset.

## Proposed solution
Invoke Drupal's `_drupal_flush_css_js();` function to re-generate the dummy query string and thus force browsers to reload fresh files.